### PR TITLE
Multi-stage build of doryd and static binary fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ TEST_ENV  = GOOS=linux GOARCH=amd64
 else
 TEST_ENV  = GOOS=$(GOOS) GOARCH=amd64
 endif
-BUILD_ENV = GOOS=linux GOARCH=amd64
+BUILD_ENV = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 
 # Add the version and hg commit id to the binary in the form of variables.
 LD_FLAGS = '-X main.Version=$(VERSION) -X main.Commit=$(COMMIT)'

--- a/build/docker/doryd/Dockerfile
+++ b/build/docker/doryd/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:latest
+ADD [ "bin/doryd", "/usr/local/bin/doryd" ]
+ENTRYPOINT [ "doryd" ]
+CMD [ "/etc/kubernetes/admin.conf", "dev.hpe.com" ]

--- a/build/docker/doryd/Dockerfile.staged
+++ b/build/docker/doryd/Dockerfile.staged
@@ -1,0 +1,11 @@
+FROM golang as builder
+RUN git clone https://github.com/hpe-storage/dory
+WORKDIR dory
+RUN make gettools && \
+    make vendor && \
+    make doryd 
+
+FROM alpine:latest
+COPY --from=builder /go/dory/bin/doryd /usr/local/bin/doryd
+ENTRYPOINT [ "doryd" ]
+CMD [ "/etc/kubernetes/admin.conf", "dev.hpe.com" ]

--- a/docs/doryd/README.md
+++ b/docs/doryd/README.md
@@ -2,7 +2,10 @@
 Doryd is an out-of-tree dynamic provisioner for Docker Volume plugins that uses the StorageClass interface available in Kubernetes. Doryd needs to have access to the cluster to listen for Persistent Volume Claims against the Storage Classes that Dory governs. Doryd also depends on [Dory](../dory/README.md), the FlexVolume driver for Docker Volume plugins.
 
 # Building (optional)
-Dory is written in Go and requires golang on your machine. The following example installs the necessary tools and builds Dory on a RHEL 7.4 system:
+There are two ways provided to build Doryd. A host machine build and a fully containerized build. The containerized build require Docker 17.05 or newer on both client and daemon.
+
+## Host build
+Doryd is written in Go and requires golang on your machine. The following example installs the necessary tools and builds Doryd on a RHEL 7.4 system:
 ```
 sudo subscription-manager repos --enable=rhel-7-server-optional-rpms
 sudo yum install -y golang make
@@ -12,20 +15,20 @@ make vendor
 make doryd
 ```
 
-You should end up with a `doryd` executable in the `./bin` directory. A `Dockerfile` is not yet available in the repository but is fairly straight-forward:
-```
-FROM alpine:latest
-ADD [ "bin/doryd", "/usr/local/bin/doryd" ]
-ENTRYPOINT [ "doryd" ]
-CMD [ "/etc/kubernetes/admin.conf", "dev.hpe.com" ]
-```
+You should end up with a `doryd` executable in the `./bin` directory.
 
-Build it with:
+Optionally, you may build a doryd container:
 ```
-docker build -t doryd:latest .
+docker build -t doryd:latest build/docker/doryd/Dockerfile .
 ```
 
 **Hint:** Go is available through the [EPEL](https://fedoraproject.org/wiki/EPEL) repository for .rpm based distributions and a `golang` package is part of the official Ubuntu repositories.
+
+## Containerized build
+Building Doryd in a container uses a multi-stage build and only require Docker 17.05 or newer.
+```
+docker build -t doryd:latest https://raw.githubusercontent.com/hpe-storage/dory/master/build/docker/doryd/Dockerfile.staged
+```
 
 # Running
 Doryd is available on Docker Hub and an [example DaemonSet specification](../../examples/ds-doryd.yaml) is available.


### PR DESCRIPTION
I discovered that Go by default builds a dynamically linked binaries by default. From the manual:
> The cgo tool is enabled by default for native builds on systems where it is expected to work. It is disabled by default when cross-compiling. You can control this by setting the CGO_ENABLED environment variable when running the go tool: set it to 1 to enable the use of cgo, and to 0 to disable it. The go tool will set the build constraint "cgo" if cgo is enabled. 

Hence dory/doryd builds fine on Macs and run on any Linux distro. ;-)

I also outlined two different ways of building doryd, full host build and containerized build. Provided Dockerfiles and instructions for both.