### PR TITLE
Add support for Docker V2 Volume Plugins

### DIFF
--- a/src/nimblestorage/cmd/dory/dory.go
+++ b/src/nimblestorage/cmd/dory/dory.go
@@ -63,8 +63,15 @@ func main() {
 		ListOfStorageResourceOptions: listOfStorageResourceOptions,
 		FactorForConversion:          factorForConversion,
 	}
-	flexvol.Config(dockervolOptions)
-	mess := flexvol.Handle(driverCommand, enable16, os.Args[2:])
+	err := flexvol.Config(dockervolOptions)
+	var mess string
+	if err != nil {
+		mess = flexvol.BuildJSONResponse(&flexvol.Response{
+			Status:  flexvol.FailureStatus,
+			Message: fmt.Sprintf("Unable to communicate with docker volume plugin - %s", err.Error())})
+	} else {
+		mess = flexvol.Handle(driverCommand, enable16, os.Args[2:])
+	}
 	util.LogInfo.Printf("[%d] reply  : %s %v: %v", pid, driverCommand, os.Args[2:], mess)
 
 	fmt.Println(mess)
@@ -103,6 +110,7 @@ func initialize() bool {
 		override = true
 		createVolumes = b
 	}
+
 	overrideFlexVol := initializeFlexVolOptions(c)
 	if overrideFlexVol {
 		override = true
@@ -123,6 +131,7 @@ func initializeFlexVolOptions(c *jconfig.Config) bool {
 		override = true
 		factorForConversion = int(i)
 	}
+
 	e16, err := c.GetBool("enable1.6")
 	if err == nil {
 		override = true

--- a/src/nimblestorage/pkg/docker/dockerlt/dockerlt.go
+++ b/src/nimblestorage/pkg/docker/dockerlt/dockerlt.go
@@ -1,0 +1,64 @@
+/*
+(c) Copyright 2018 Hewlett Packard Enterprise Development LP
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockerlt
+
+import (
+	"nimblestorage/pkg/connectivity"
+	"nimblestorage/pkg/util"
+)
+
+const (
+	defaultSocketPath = "/var/run/docker.sock"
+)
+
+// DockerClient is a light weight docker client
+type DockerClient struct {
+	client *connectivity.Client
+}
+
+type errorResponse struct {
+	Message string `json:"message,omitempty"`
+}
+
+// NewDockerClient provides a light weight docker client connection
+func NewDockerClient(socketPath string) *DockerClient {
+	if socketPath == "" {
+		socketPath = defaultSocketPath
+	}
+	return &DockerClient{connectivity.NewSocketClient(socketPath)}
+}
+
+// PluginsGet does a GET against /plugins
+func (dc *DockerClient) PluginsGet() ([]Plugin, error) {
+	plugins := make([]Plugin, 0)
+	apiError := &errorResponse{}
+
+	err := dc.client.DoJSON(&connectivity.Request{
+		Action:        "GET",
+		Path:          "/plugins",
+		Payload:       nil,
+		Response:      &plugins,
+		ResponseError: apiError})
+
+	if err != nil {
+		util.LogInfo.Printf("unable to list docker plugins - %s (%s)", err.Error(), apiError.Message)
+		return nil, err
+	}
+
+	util.LogDebug.Printf("returning %#v", plugins)
+	return plugins, nil
+}

--- a/src/nimblestorage/pkg/docker/dockerlt/plugin.go
+++ b/src/nimblestorage/pkg/docker/dockerlt/plugin.go
@@ -1,0 +1,35 @@
+/*
+(c) Copyright 2018 Hewlett Packard Enterprise Development LP
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockerlt
+
+// Plugin describes a Docker v2 plugin
+type Plugin struct {
+	ID      string       `json:"Id,omitempty"`
+	Name    string       `json:"Name,omitempty"`
+	Enabled bool         `json:"Enabled,omitempty"`
+	Config  PluginConfig `json:"Config,omitempty"`
+}
+
+// PluginConfig describes the config for the plugin
+type PluginConfig struct {
+	Interface PluginInterface `json:"Interface,omitempty"`
+}
+
+// PluginInterface describes the interface used by docker to communicate with this plugin
+type PluginInterface struct {
+	Socket string `json:"Socket,omitempty"`
+}

--- a/src/nimblestorage/pkg/docker/dockervol/dockervol.go
+++ b/src/nimblestorage/pkg/docker/dockervol/dockervol.go
@@ -131,8 +131,9 @@ type PluginCapabilities struct {
 }
 
 // NewDockerVolumePlugin creates a DockerVolumePlugin which can be used to communicate with
-// a Docker Volume Plugin.  socketPath is the full path to the location of the socket file for the nimble volume plugin.
-// stripK8sFromOptions indicates if k8s namespace should be stripped fromoptions.
+// a Docker Volume Plugin.  options.socketPath can be the full path to the socket file or
+// the name of a Docker V2 plugin.  In the case of the V2 plugin, the name of th plugin
+// is used to look up the full path to the socketfile.
 func NewDockerVolumePlugin(options *Options) (*DockerVolumePlugin, error) {
 	var err error
 	if !strings.HasPrefix(options.SocketPath, "/") {

--- a/src/nimblestorage/pkg/docker/dockervol/dockervol.go
+++ b/src/nimblestorage/pkg/docker/dockervol/dockervol.go
@@ -19,6 +19,7 @@ package dockervol
 import (
 	"fmt"
 	"nimblestorage/pkg/connectivity"
+	"nimblestorage/pkg/docker/dockerlt"
 	"nimblestorage/pkg/util"
 	"strings"
 )
@@ -119,19 +120,69 @@ type DockerVolume struct {
 	Status     map[string]interface{} `json:"Status,omitempty"`
 }
 
+//CapResponse describes the capabilities of the plugin
+type CapResponse struct {
+	Capabilities PluginCapabilities `json:"Capabilities,omitempty"`
+}
+
+//PluginCapabilities includes the scope of the plugin
+type PluginCapabilities struct {
+	Scope string `json:"Scope,omitempty"`
+}
+
 // NewDockerVolumePlugin creates a DockerVolumePlugin which can be used to communicate with
 // a Docker Volume Plugin.  socketPath is the full path to the location of the socket file for the nimble volume plugin.
 // stripK8sFromOptions indicates if k8s namespace should be stripped fromoptions.
-func NewDockerVolumePlugin(options *Options) *DockerVolumePlugin {
+func NewDockerVolumePlugin(options *Options) (*DockerVolumePlugin, error) {
+	var err error
+	if !strings.HasPrefix(options.SocketPath, "/") {
+		// this is a v2 plugin, so we need to find its socket file
+		options.SocketPath, err = getV2PluginSocket(options.SocketPath, "")
+	}
+	if err != nil {
+		return nil, err
+	}
+
 	if options.SocketPath == "" {
 		options.SocketPath = defaultSocketPath
 	}
-	return &DockerVolumePlugin{
+	dvp := &DockerVolumePlugin{
 		stripK8sOpts: options.StripK8sFromOptions,
 		client:       connectivity.NewSocketClient(options.SocketPath),
 		ListOfStorageResourceOptions: options.ListOfStorageResourceOptions,
 		FactorForConversion:          options.FactorForConversion,
 	}
+
+	// test connectivity
+	_, err = dvp.Capabilities()
+	if err != nil {
+		return dvp, err
+	}
+
+	return dvp, nil
+
+}
+
+type empty struct{}
+
+//Capabilities returns the capabilities supported by the plugin
+func (dvp *DockerVolumePlugin) Capabilities() (*CapResponse, error) {
+	var req = &empty{}
+	var res = &CapResponse{}
+
+	err := dvp.driverRun(&connectivity.Request{
+		Action:        "POST",
+		Path:          CapabilitiesURI,
+		Payload:       req,
+		Response:      res,
+		ResponseError: res})
+	if err != nil {
+		util.LogInfo.Printf("unable to get Capabilities - %s\n", err.Error())
+		return nil, err
+	}
+
+	util.LogDebug.Printf("returning %#v", res)
+	return res, nil
 }
 
 //Get a docker volume by docker name returning the response from the driver
@@ -294,4 +345,25 @@ func driverErrorCheck(e Errorer) error {
 		return fmt.Errorf(e.getErr())
 	}
 	return nil
+}
+
+// name is the name of the docker volume plugin.  dockerSocket is the full path to the docker socket.  The default is used if an empty string is passed.
+func getV2PluginSocket(name, dockerSocket string) (string, error) {
+	c := dockerlt.NewDockerClient(dockerSocket)
+	plugins, err := c.PluginsGet()
+
+	if err != nil {
+		return "", fmt.Errorf("failed to get V2 plugins from docker. error=%s", err.Error())
+	}
+
+	for _, plugin := range plugins {
+		if strings.Compare(name, plugin.Name) == 0 || strings.Compare(fmt.Sprintf("%s:latest", name), plugin.Name) == 0 {
+			if !plugin.Enabled {
+				return fmt.Sprintf("/run/docker/plugins/%s/%s", plugin.ID, plugin.Config.Interface.Socket), fmt.Errorf("found Docker V2 Plugin named %s, but it is disabled", name)
+			}
+			return fmt.Sprintf("/run/docker/plugins/%s/%s", plugin.ID, plugin.Config.Interface.Socket), nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to find V2 plugin named %s", name)
 }

--- a/src/nimblestorage/pkg/k8s/flexvol/flexvol.go
+++ b/src/nimblestorage/pkg/k8s/flexvol/flexvol.go
@@ -94,9 +94,10 @@ func (ar *AttachRequest) getBestName() string {
 }
 
 // Config controls the docker behavior
-func Config(options *dockervol.Options) {
-	dvp = dockervol.NewDockerVolumePlugin(options)
+func Config(options *dockervol.Options) (err error) {
+	dvp, err = dockervol.NewDockerVolumePlugin(options)
 	createVolumes = options.CreateVolumes
+	return err
 }
 
 // BuildJSONResponse marshals a message into the FlexVolume JSON Response.


### PR DESCRIPTION
 * dory & doryd will lookup the socket name of the v2 plugin specified
   specified in the json config file
 * A Capabilities query is used to test the connection before returning
   a client so that we fail fast
 * Super light weight docker client added that only looks up plugins
   (go docker sdk is huge, but does everything)