### PR TITLE
Provide a way to dump the config options

### DIFF
--- a/src/nimblestorage/cmd/dory/dory_test.go
+++ b/src/nimblestorage/cmd/dory/dory_test.go
@@ -1,0 +1,121 @@
+/*
+(c) Copyright 2017 Hewlett Packard Enterprise Development LP
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+)
+
+var basicTests = []struct {
+	name                         string
+	override                     bool
+	dockerVolumePluginSocketPath string
+	stripK8sFromOptions          bool
+	logFilePath                  string
+	debug                        bool
+	createVolumes                bool
+	enable16                     bool
+	factorForConversion          int
+	listOfStorageResourceOptions []string
+}{
+	{"test/good", true, "/run/docker/plugins/nimble.sock", true, "/var/log/dory.log", false, true, false, 1073741824, []string{"size", "sizeInGiB"}},
+	{"test/flipped", true, "nimble", false, "some path", true, false, true, 14, []string{"size", "sizeInGiB", "w", "x", "y", "z"}},
+	{"test/broken", false, "/run/docker/plugins/nimble.sock", true, "/var/log/dory.log", false, true, false, 1073741824, []string{"size", "sizeInGiB"}},
+	{"test/errors", true, "21", true, "true", false, true, false, 1073741824, []string{"size", "sizeInGiB"}},
+}
+
+// nolint: gocyclo
+func TestConfigFiles(t *testing.T) {
+	for _, tc := range basicTests {
+		t.Run(tc.name, func(t *testing.T) {
+			//reset for each test
+			dockerVolumePluginSocketPath = "/run/docker/plugins/nimble.sock"
+			stripK8sFromOptions = true
+			logFilePath = "/var/log/dory.log"
+			debug = false
+			createVolumes = true
+			enable16 = false
+			factorForConversion = 1073741824
+			listOfStorageResourceOptions = []string{"size", "sizeInGiB"}
+
+			override := initialize(tc.name, true)
+			if override != tc.override {
+				t.Error(
+					"For", "override",
+					"expected", tc.override,
+					"got:", override,
+				)
+			}
+			if dockerVolumePluginSocketPath != tc.dockerVolumePluginSocketPath {
+				t.Error(
+					"For", "dockerVolumePluginSocketPath",
+					"expected", tc.dockerVolumePluginSocketPath,
+					"got:", dockerVolumePluginSocketPath,
+				)
+			}
+			if stripK8sFromOptions != tc.stripK8sFromOptions {
+				t.Error(
+					"For", "stripK8sFromOptions",
+					"expected", tc.stripK8sFromOptions,
+					"got:", stripK8sFromOptions,
+				)
+			}
+			if logFilePath != tc.logFilePath {
+				t.Error(
+					"For", "logFilePath",
+					"expected", tc.logFilePath,
+					"got:", logFilePath,
+				)
+			}
+			if debug != tc.debug {
+				t.Error(
+					"For", "debug",
+					"expected", tc.debug,
+					"got:", debug,
+				)
+			}
+			if createVolumes != tc.createVolumes {
+				t.Error(
+					"For", "createVolumes",
+					"expected", tc.createVolumes,
+					"got:", createVolumes,
+				)
+			}
+			if enable16 != tc.enable16 {
+				t.Error(
+					"For", "enable16",
+					"expected", tc.enable16,
+					"got:", enable16,
+				)
+			}
+			if factorForConversion != tc.factorForConversion {
+				t.Error(
+					"For", "factorForConversion",
+					"expected", tc.factorForConversion,
+					"got:", factorForConversion,
+				)
+			}
+			if len(listOfStorageResourceOptions) != len(tc.listOfStorageResourceOptions) {
+				t.Error(
+					"For", "listOfStorageResourceOptions",
+					"expected", tc.listOfStorageResourceOptions,
+					"got:", listOfStorageResourceOptions,
+				)
+			}
+		})
+	}
+}

--- a/src/nimblestorage/cmd/dory/test/broken.json
+++ b/src/nimblestorage/cmd/dory/test/broken.json
@@ -1,0 +1,10 @@
+{
+    "logFilePath": bool,
+    "logDebug": 32,
+    "stripK8sFromOptions": 32,
+    "dockerVolumePluginSocketPath": 21,
+    "createVolumes": "oops"
+    "enable1.6": 123.23
+    "listOfStorageResourceOptions" : [ "234", 567],
+    "factorForConversion": "oops"
+}

--- a/src/nimblestorage/cmd/dory/test/errors.json
+++ b/src/nimblestorage/cmd/dory/test/errors.json
@@ -1,0 +1,9 @@
+{
+    "logFilePath": true,
+    "logDebug": 32,
+    "stripK8sFromOptions": 32,
+    "dockerVolumePluginSocketPath": 21,
+    "createVolumes": "oops",
+    "enable1.6": 123.23,
+    "factorForConversion": "oops"
+}

--- a/src/nimblestorage/cmd/dory/test/flipped.json
+++ b/src/nimblestorage/cmd/dory/test/flipped.json
@@ -1,0 +1,10 @@
+{
+    "logFilePath": "some path",
+    "logDebug": true,
+    "stripK8sFromOptions": false,
+    "dockerVolumePluginSocketPath": "nimble",
+    "createVolumes": false,
+    "enable1.6": true,
+    "listOfStorageResourceOptions" : ["size","sizeInGiB","w","x","y","z"],
+    "factorForConversion": 14
+}

--- a/src/nimblestorage/cmd/dory/test/good.json
+++ b/src/nimblestorage/cmd/dory/test/good.json
@@ -1,0 +1,10 @@
+{
+    "logFilePath": "/var/log/dory.log",
+    "logDebug": false,
+    "stripK8sFromOptions": true,
+    "dockerVolumePluginSocketPath": "/run/docker/plugins/nimble.sock",
+    "createVolumes": true,
+    "enable1.6": false,
+    "listOfStorageResourceOptions" : ["size","sizeInGiB"],
+    "factorForConversion": 1073741824
+    }


### PR DESCRIPTION
The config command argument provides error checking and displays the values for each option.

Example:
`$./dory config

Driver=dory Version=1234
Current Config:
  dockerVolumePluginSocketPath = /run/docker/plugins/nimble.sock
           stripK8sFromOptions = true
                   logFilePath = /var/log/dory.log
                      logDebug = false
                 createVolumes = true
                     enable1.6 = true
           factorForConversion = 1073741824
  listOfStorageResourceOptions = [size sizeInGiB]`