### PR TITLE
Support skipping the capabilities check

### DIFF
--- a/src/nimblestorage/cmd/dory/dory.go
+++ b/src/nimblestorage/cmd/dory/dory.go
@@ -37,6 +37,7 @@ const (
 	optEnable16                     = "enable1.6"
 	optFactorForConversion          = "factorForConversion"
 	optListOfStorageResourceOptions = "listOfStorageResourceOptions"
+	optSupportsCapabilities         = "supportsCapabilities"
 )
 
 var (
@@ -53,6 +54,7 @@ var (
 	enable16                     = false
 	factorForConversion          = 1073741824
 	listOfStorageResourceOptions = []string{"size", "sizeInGiB"}
+	supportsCapabilities         = true
 )
 
 func main() {
@@ -84,6 +86,7 @@ func main() {
 		CreateVolumes:                createVolumes,
 		ListOfStorageResourceOptions: listOfStorageResourceOptions,
 		FactorForConversion:          factorForConversion,
+		SupportsCapabilities:         supportsCapabilities,
 	}
 	err := flexvol.Config(dockervolOptions)
 	var mess string
@@ -134,6 +137,14 @@ func initialize(name string, report bool) bool {
 		debug = b
 	} else {
 		configOptCheck(report, optDebug, err)
+	}
+
+	b, err = c.GetBool(optSupportsCapabilities)
+	if err == nil {
+		override = true
+		supportsCapabilities = b
+	} else {
+		configOptCheck(report, optSupportsCapabilities, err)
 	}
 
 	overrideFlexVol := initializeFlexVolOptions(c, report)
@@ -210,5 +221,6 @@ func configOptDump(report bool) {
 	fmt.Printf("%30s = %t\n", optEnable16, enable16)
 	fmt.Printf("%30s = %d\n", optFactorForConversion, factorForConversion)
 	fmt.Printf("%30s = %v\n", optListOfStorageResourceOptions, listOfStorageResourceOptions)
+	fmt.Printf("%30s = %t\n", optSupportsCapabilities, supportsCapabilities)
 
 }

--- a/src/nimblestorage/cmd/dory/dory_test.go
+++ b/src/nimblestorage/cmd/dory/dory_test.go
@@ -31,11 +31,12 @@ var basicTests = []struct {
 	enable16                     bool
 	factorForConversion          int
 	listOfStorageResourceOptions []string
+	supportsCapabilities         bool
 }{
-	{"test/good", true, "/run/docker/plugins/nimble.sock", true, "/var/log/dory.log", false, true, false, 1073741824, []string{"size", "sizeInGiB"}},
-	{"test/flipped", true, "nimble", false, "some path", true, false, true, 14, []string{"size", "sizeInGiB", "w", "x", "y", "z"}},
-	{"test/broken", false, "/run/docker/plugins/nimble.sock", true, "/var/log/dory.log", false, true, false, 1073741824, []string{"size", "sizeInGiB"}},
-	{"test/errors", true, "21", true, "true", false, true, false, 1073741824, []string{"size", "sizeInGiB"}},
+	{"test/good", true, "/run/docker/plugins/nimble.sock", true, "/var/log/dory.log", false, true, false, 1073741824, []string{"size", "sizeInGiB"}, true},
+	{"test/flipped", true, "nimble", false, "some path", true, false, true, 14, []string{"size", "sizeInGiB", "w", "x", "y", "z"}, false},
+	{"test/broken", false, "/run/docker/plugins/nimble.sock", true, "/var/log/dory.log", false, true, false, 1073741824, []string{"size", "sizeInGiB"}, true},
+	{"test/errors", true, "21", true, "true", false, true, false, 1073741824, []string{"size", "sizeInGiB"}, true},
 }
 
 // nolint: gocyclo
@@ -51,6 +52,7 @@ func TestConfigFiles(t *testing.T) {
 			enable16 = false
 			factorForConversion = 1073741824
 			listOfStorageResourceOptions = []string{"size", "sizeInGiB"}
+			supportsCapabilities = true
 
 			override := initialize(tc.name, true)
 			if override != tc.override {
@@ -114,6 +116,13 @@ func TestConfigFiles(t *testing.T) {
 					"For", "listOfStorageResourceOptions",
 					"expected", tc.listOfStorageResourceOptions,
 					"got:", listOfStorageResourceOptions,
+				)
+			}
+			if supportsCapabilities != tc.supportsCapabilities {
+				t.Error(
+					"For", "supportsCapabilities",
+					"expected", tc.supportsCapabilities,
+					"got:", supportsCapabilities,
 				)
 			}
 		})

--- a/src/nimblestorage/cmd/dory/test/flipped.json
+++ b/src/nimblestorage/cmd/dory/test/flipped.json
@@ -6,5 +6,6 @@
     "createVolumes": false,
     "enable1.6": true,
     "listOfStorageResourceOptions" : ["size","sizeInGiB","w","x","y","z"],
-    "factorForConversion": 14
+    "factorForConversion": 14,
+    "supportsCapabilities": false
 }

--- a/src/nimblestorage/cmd/dory/test/good.json
+++ b/src/nimblestorage/cmd/dory/test/good.json
@@ -6,5 +6,6 @@
     "createVolumes": true,
     "enable1.6": false,
     "listOfStorageResourceOptions" : ["size","sizeInGiB"],
-    "factorForConversion": 1073741824
-    }
+    "factorForConversion": 1073741824,
+    "supportsCapabilities": true
+}

--- a/src/nimblestorage/pkg/docker/dockervol/dockervol.go
+++ b/src/nimblestorage/pkg/docker/dockervol/dockervol.go
@@ -56,6 +56,7 @@ type Options struct {
 	CreateVolumes                bool
 	ListOfStorageResourceOptions []string
 	FactorForConversion          int
+	SupportsCapabilities         bool
 }
 
 //DockerVolumePlugin is the client to a specific docker volume plugin
@@ -154,10 +155,12 @@ func NewDockerVolumePlugin(options *Options) (*DockerVolumePlugin, error) {
 		FactorForConversion:          options.FactorForConversion,
 	}
 
-	// test connectivity
-	_, err = dvp.Capabilities()
-	if err != nil {
-		return dvp, err
+	if options.SupportsCapabilities {
+		// test connectivity
+		_, err = dvp.Capabilities()
+		if err != nil {
+			return dvp, err
+		}
 	}
 
 	return dvp, nil


### PR DESCRIPTION
To address issue #23 -
If supportsCapabilities is true, make this call to test connectivity.
If supportsCapabilities is false, skip the logic that makes this call.

Default value:
    "supportsCapabilities": true