### PR TITLE
Possible fix for issue #36 for mount issue of POD with managed plugin

### DIFF
--- a/cmd/dory/dory.go
+++ b/cmd/dory/dory.go
@@ -87,6 +87,7 @@ func main() {
 		ListOfStorageResourceOptions: listOfStorageResourceOptions,
 		FactorForConversion:          factorForConversion,
 		SupportsCapabilities:         supportsCapabilities,
+                ManagedPluginID:              "",
 	}
 	err := flexvol.Config(dockervolOptions)
 	var mess string

--- a/common/docker/dockervol/dockervol.go
+++ b/common/docker/dockervol/dockervol.go
@@ -413,3 +413,25 @@ func getV2PluginSocket(name, dockerSocket string) (string, error) {
 
 	return "", fmt.Errorf("unable to find V2 plugin named %s", name)
 }
+// GetV2PluginID - name is the name of the plugin and this function returns the 
+// plugin ID of the managed plugin
+func GetV2PluginID(name, dockerSocket string) (string, error) {
+	c := dockerlt.NewDockerClient(dockerSocket)
+	plugins, err := c.PluginsGet()
+
+	if err != nil {
+		return "", fmt.Errorf("failed to get V2 plugins from docker. error=%s", err.Error())
+	}
+
+	for _, plugin := range plugins {
+		if strings.Compare(name, plugin.Name) == 0 || strings.Compare(fmt.Sprintf("%s:latest", name), plugin.Name) == 0 {
+			if !plugin.Enabled {
+				return fmt.Sprintf("/run/docker/plugins/%s/%s", plugin.ID, plugin.Config.Interface.Socket), fmt.Errorf("found Docker V2 Plugin named %s, but it is disabled", name)
+			}
+
+			return plugin.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to find V2 plugin ID %s", name)
+}

--- a/common/docker/dockervol/dockervol.go
+++ b/common/docker/dockervol/dockervol.go
@@ -48,6 +48,7 @@ const (
 	NotFound = "Unable to find"
 
 	defaultSocketPath = "/run/docker/plugins/nimble.sock"
+        //managedPluginID = ""
 	maxTries          = 3
 )
 
@@ -61,6 +62,7 @@ type Options struct {
 	ListOfStorageResourceOptions []string
 	FactorForConversion          int
 	SupportsCapabilities         bool
+        ManagedPluginID            string
 }
 
 //DockerVolumePlugin is the client to a specific docker volume plugin
@@ -143,7 +145,7 @@ func NewDockerVolumePlugin(options *Options) (*DockerVolumePlugin, error) {
 	var err error
 	if !strings.HasPrefix(options.SocketPath, "/") {
 		// this is a v2 plugin, so we need to find its socket file
-		options.SocketPath, err = getV2PluginSocket(options.SocketPath, "")
+		options.SocketPath, options.ManagedPluginID, err = getV2PluginSocket(options.SocketPath, "")
 	}
 	if err != nil {
 		return nil, err
@@ -394,44 +396,22 @@ func driverErrorCheck(e Errorer) error {
 }
 
 // name is the name of the docker volume plugin.  dockerSocket is the full path to the docker socket.  The default is used if an empty string is passed.
-func getV2PluginSocket(name, dockerSocket string) (string, error) {
+func getV2PluginSocket(name, dockerSocket string) (string, string, error) {
 	c := dockerlt.NewDockerClient(dockerSocket)
 	plugins, err := c.PluginsGet()
 
 	if err != nil {
-		return "", fmt.Errorf("failed to get V2 plugins from docker. error=%s", err.Error())
+		return "", "", fmt.Errorf("failed to get V2 plugins from docker. error=%s", err.Error())
 	}
 
 	for _, plugin := range plugins {
 		if strings.Compare(name, plugin.Name) == 0 || strings.Compare(fmt.Sprintf("%s:latest", name), plugin.Name) == 0 {
 			if !plugin.Enabled {
-				return fmt.Sprintf("/run/docker/plugins/%s/%s", plugin.ID, plugin.Config.Interface.Socket), fmt.Errorf("found Docker V2 Plugin named %s, but it is disabled", name)
+				return fmt.Sprintf("/run/docker/plugins/%s/%s", plugin.ID, plugin.Config.Interface.Socket), "", fmt.Errorf("found Docker V2 Plugin named %s, but it is disabled", name)
 			}
-			return fmt.Sprintf("/run/docker/plugins/%s/%s", plugin.ID, plugin.Config.Interface.Socket), nil
+			return fmt.Sprintf("/run/docker/plugins/%s/%s", plugin.ID, plugin.Config.Interface.Socket), plugin.ID, nil
 		}
 	}
 
-	return "", fmt.Errorf("unable to find V2 plugin named %s", name)
-}
-// GetV2PluginID - name is the name of the plugin and this function returns the 
-// plugin ID of the managed plugin
-func GetV2PluginID(name, dockerSocket string) (string, error) {
-	c := dockerlt.NewDockerClient(dockerSocket)
-	plugins, err := c.PluginsGet()
-
-	if err != nil {
-		return "", fmt.Errorf("failed to get V2 plugins from docker. error=%s", err.Error())
-	}
-
-	for _, plugin := range plugins {
-		if strings.Compare(name, plugin.Name) == 0 || strings.Compare(fmt.Sprintf("%s:latest", name), plugin.Name) == 0 {
-			if !plugin.Enabled {
-				return fmt.Sprintf("/run/docker/plugins/%s/%s", plugin.ID, plugin.Config.Interface.Socket), fmt.Errorf("found Docker V2 Plugin named %s, but it is disabled", name)
-			}
-
-			return plugin.ID, nil
-		}
-	}
-
-	return "", fmt.Errorf("unable to find V2 plugin ID %s", name)
+	return "", "", fmt.Errorf("unable to find V2 plugin named %s", name)
 }

--- a/common/docker/dockervol/dockervol.go
+++ b/common/docker/dockervol/dockervol.go
@@ -48,7 +48,6 @@ const (
 	NotFound = "Unable to find"
 
 	defaultSocketPath = "/run/docker/plugins/nimble.sock"
-        //managedPluginID = ""
 	maxTries          = 3
 )
 

--- a/common/k8s/flexvol/flexvol.go
+++ b/common/k8s/flexvol/flexvol.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"time"
+        "strings"
 )
 
 const (
@@ -338,7 +339,8 @@ func getVolumeNameFromMountPath(k8sPath, dockerPath string) (string, error) {
 			return "", err
 		}
 		for _, vol := range volumes.Volumes {
-			if vol.Mountpoint == dockerPath {
+			if (vol.Mountpoint == dockerPath || (strings.Contains(dockerPath, vol.Mountpoint) && strings.HasPrefix(dockerPath,"/var/lib/docker"))) {
+                                util.LogDebug.Printf("dockerPath %s, volume mountpoint %s", dockerPath, vol.Mountpoint)
 				return vol.Name, nil
 			}
 		}

--- a/common/k8s/flexvol/flexvol.go
+++ b/common/k8s/flexvol/flexvol.go
@@ -228,7 +228,17 @@ func Mount(args []string) (string, error) {
 	//Bind mount the docker path to the flexvol path
 	err = linux.BindMount(path, args[0], false)
 	if err != nil {
-		return "", err
+		pluginID, _ := dockervol.GetV2PluginID("hpe:latest", "")
+		pathForManagedPlugin := "/var/lib/docker/plugins/" + pluginID + "/rootfs"+ path
+
+		//args := []string{flag, pathForManagedPlugin, mountPoint}
+		//_, _, err := util.ExecCommandOutput(mountCommand, args)
+		err = linux.BindMount(pathForManagedPlugin, args[0], false)
+
+		if err != nil {
+			return "", err
+		}
+		path = pathForManagedPlugin
 	}
 
 	// Set selinux context if configured

--- a/common/k8s/flexvol/flexvol.go
+++ b/common/k8s/flexvol/flexvol.go
@@ -339,8 +339,10 @@ func getVolumeNameFromMountPath(k8sPath, dockerPath string) (string, error) {
 			return "", err
 		}
 		for _, vol := range volumes.Volumes {
-			if (vol.Mountpoint == dockerPath || (strings.Contains(dockerPath, vol.Mountpoint) && strings.HasPrefix(dockerPath,"/var/lib/docker"))) {
-                                util.LogDebug.Printf("dockerPath %s, volume mountpoint %s", dockerPath, vol.Mountpoint)
+
+                        util.LogDebug.Printf("dockerPath %s, volume mountpoint %s", dockerPath, vol.Mountpoint)
+			if (vol.Mountpoint == dockerPath || (findStringAfterLastSlash(vol.Mountpoint) == findStringAfterLastSlash(dockerPath))){
+                                util.LogDebug.Printf(" returning docker volume name %s", vol.Name)
 				return vol.Name, nil
 			}
 		}
@@ -359,4 +361,14 @@ func findJSON(args []string, req *AttachRequest) (string, error) {
 		}
 	}
 	return "", err
+}
+func findStringAfterLastSlash(s string) string {
+
+	//s := "/var/lib/docker/plugins/a238188db964f8139af8d502a9b134b1f9522ccc27936ae5512b2f1b662f0aa5/rootfs/opt/hpe/data/hpedocker-dm-uuid-mpath-360002ac0000000000101331f00019d52"
+
+	flds := strings.Split(s, "/")
+	arrayLength := len(flds)
+	fmt.Printf(" Length = %d, last substring %s" ,arrayLength, flds[arrayLength -1])
+	return flds[arrayLength - 1]
+
 }

--- a/common/k8s/flexvol/flexvol.go
+++ b/common/k8s/flexvol/flexvol.go
@@ -60,6 +60,7 @@ const (
 var (
 	//createVolumes indicate whether the driver should create missing volumes
 	createVolumes = true
+        pluginID = ""
 
 	dvp *dockervol.DockerVolumePlugin
 )
@@ -99,6 +100,7 @@ func (ar *AttachRequest) getBestName() string {
 func Config(options *dockervol.Options) (err error) {
 	dvp, err = dockervol.NewDockerVolumePlugin(options)
 	createVolumes = options.CreateVolumes
+        pluginID = options.ManagedPluginID
 	return err
 }
 
@@ -228,11 +230,8 @@ func Mount(args []string) (string, error) {
 	//Bind mount the docker path to the flexvol path
 	err = linux.BindMount(path, args[0], false)
 	if err != nil {
-		pluginID, _ := dockervol.GetV2PluginID("hpe:latest", "")
 		pathForManagedPlugin := "/var/lib/docker/plugins/" + pluginID + "/rootfs"+ path
-
-		//args := []string{flag, pathForManagedPlugin, mountPoint}
-		//_, _, err := util.ExecCommandOutput(mountCommand, args)
+		util.LogDebug.Printf("pathForManagedPlugin: %s", pathForManagedPlugin)	
 		err = linux.BindMount(pathForManagedPlugin, args[0], false)
 
 		if err != nil {

--- a/common/linux/bmount.go
+++ b/common/linux/bmount.go
@@ -18,6 +18,7 @@ package linux
 
 import (
 	"github.com/hpe-storage/dory/common/util"
+	"github.com/hpe-storage/dory/common/docker/dockervol"
 	"strings"
 )
 
@@ -49,6 +50,12 @@ func BindMount(path, mountPoint string, rbind bool) error {
 	out, rc, err := util.ExecCommandOutput(mountCommand, args)
 	if err != nil {
 		util.LogError.Printf("BindMount failed with %d.  It was called with %s %s %v.  Output=%v.", rc, path, mountPoint, rbind, out)
+
+		pluginID, _ := dockervol.GetV2PluginID("hpe:latest", "")
+		pathForManagedPlugin := "/var/lib/docker/plugins/" + pluginID + "/rootfs"+ path
+
+		args := []string{flag, pathForManagedPlugin, mountPoint}
+		_, _, err := util.ExecCommandOutput(mountCommand, args)
 		return err
 	}
 

--- a/common/linux/bmount.go
+++ b/common/linux/bmount.go
@@ -49,7 +49,6 @@ func BindMount(path, mountPoint string, rbind bool) error {
 	out, rc, err := util.ExecCommandOutput(mountCommand, args)
 	if err != nil {
 		util.LogError.Printf("BindMount failed with %d.  It was called with %s %s %v.  Output=%v.", rc, path, mountPoint, rbind, out)
-
 		return err
 	}
 

--- a/common/linux/bmount.go
+++ b/common/linux/bmount.go
@@ -18,7 +18,6 @@ package linux
 
 import (
 	"github.com/hpe-storage/dory/common/util"
-	"github.com/hpe-storage/dory/common/docker/dockervol"
 	"strings"
 )
 
@@ -51,11 +50,6 @@ func BindMount(path, mountPoint string, rbind bool) error {
 	if err != nil {
 		util.LogError.Printf("BindMount failed with %d.  It was called with %s %s %v.  Output=%v.", rc, path, mountPoint, rbind, out)
 
-		pluginID, _ := dockervol.GetV2PluginID("hpe:latest", "")
-		pathForManagedPlugin := "/var/lib/docker/plugins/" + pluginID + "/rootfs"+ path
-
-		args := []string{flag, pathForManagedPlugin, mountPoint}
-		_, _, err := util.ExecCommandOutput(mountCommand, args)
 		return err
 	}
 


### PR DESCRIPTION
- This is a possible fix for the issue #36 , where the mount folder path for the managed plugin is handled
- I did see some unit tests failed which i will address on next commit
```
[docker@cld13b4 dory]$ make test
» test
»» Package unit tests
for pkg in github.com/hpe-storage/dory/common/chain github.com/hpe-storage/dory/common/connectivity github.com/hpe-storage/dory/common/docker/dockerlt github.com/hpe-storage/dory/common/docker/dockervol github.com/hpe-storage/dory/common/jconfig github.com/hpe-storage/dory/common/k8s/flexvol github.com/hpe-storage/dory/common/k8s/provisioner github.com/hpe-storage/dory/common/linux github.com/hpe-storage/dory/common/util; do echo "»»» Testing $pkg:" && export GOPATH=/home/docker/my_dory_fork PATH=$PATH:/home/docker/my_dory_fork/bin GOOS=linux GOARCH=amd64 && go test -cover $pkg; done
»»» Testing github.com/hpe-storage/dory/common/chain:
ok      github.com/hpe-storage/dory/common/chain        0.008s  coverage: 100.0% of statements
»»» Testing github.com/hpe-storage/dory/common/connectivity:
ok      github.com/hpe-storage/dory/common/connectivity 14.024s coverage: 78.0% of statements
»»» Testing github.com/hpe-storage/dory/common/docker/dockerlt:
?       github.com/hpe-storage/dory/common/docker/dockerlt      [no test files]
»»» Testing github.com/hpe-storage/dory/common/docker/dockervol:
?       github.com/hpe-storage/dory/common/docker/dockervol     [no test files]
»»» Testing github.com/hpe-storage/dory/common/jconfig:
ok      github.com/hpe-storage/dory/common/jconfig      0.005s  coverage: 100.0% of statements
»»» Testing github.com/hpe-storage/dory/common/k8s/flexvol:
ok      github.com/hpe-storage/dory/common/k8s/flexvol  0.009s  coverage: 9.9% of statements
»»» Testing github.com/hpe-storage/dory/common/k8s/provisioner:
ok      github.com/hpe-storage/dory/common/k8s/provisioner      0.201s  coverage: 11.0% of statements
»»» Testing github.com/hpe-storage/dory/common/linux:
--- FAIL: TestGetDeviceFromMountPoint (0.00s)
        bmount_test.go:37: For dev expected /dev/sda1 got /dev/sda2
--- FAIL: TestGetMountPointFromDevice (0.00s)
        bmount_test.go:53: For mountpoint expected /boot got /boot/efi
FAIL
coverage: 33.3% of statements
FAIL    github.com/hpe-storage/dory/common/linux        0.013s
»»» Testing github.com/hpe-storage/dory/common/util:
ok      github.com/hpe-storage/dory/common/util 0.035s  coverage: 21.1% of statements
»» Command unit tests
for cmd in github.com/hpe-storage/dory/cmd/dory github.com/hpe-storage/dory/cmd/doryd; do echo "»»» Testing $cmd:" && export GOPATH=/home/docker/my_dory_fork PATH=$PATH:/home/docker/my_dory_fork/bin GOOS=linux GOARCH=amd64 && go test -cover $cmd; done
»»» Testing github.com/hpe-storage/dory/cmd/dory:
ok      github.com/hpe-storage/dory/cmd/dory    0.009s  coverage: 72.9% of statements
»»» Testing github.com/hpe-storage/dory/cmd/doryd:
?       github.com/hpe-storage/dory/cmd/doryd   [no test files]
```