### PR TITLE
dory : enhancements to support PVC/POD scale

### DIFF
--- a/common/docker/dockerlt/dockerlt.go
+++ b/common/docker/dockerlt/dockerlt.go
@@ -19,10 +19,12 @@ package dockerlt
 import (
 	"github.com/hpe-storage/dory/common/connectivity"
 	"github.com/hpe-storage/dory/common/util"
+	"time"
 )
 
 const (
-	defaultSocketPath = "/var/run/docker.sock"
+	defaultSocketPath         = "/var/run/docker.sock"
+	dockerClientSocketTimeout = time.Duration(300) * time.Second
 )
 
 // DockerClient is a light weight docker client
@@ -39,7 +41,7 @@ func NewDockerClient(socketPath string) *DockerClient {
 	if socketPath == "" {
 		socketPath = defaultSocketPath
 	}
-	return &DockerClient{connectivity.NewSocketClient(socketPath)}
+	return &DockerClient{connectivity.NewSocketClientWithTimeout(socketPath, dockerClientSocketTimeout)}
 }
 
 // PluginsGet does a GET against /plugins

--- a/common/k8s/provisioner/class.go
+++ b/common/k8s/provisioner/class.go
@@ -84,7 +84,8 @@ func (p *Provisioner) getClassOverrides(optionsMap map[string]string) []string {
 	if val, ok := optionsMap[allowOverrides]; ok {
 		util.LogDebug.Printf("allowOverrides %s", val)
 		for k, v := range strings.Split(val, ",") {
-			v = strings.Trim(v, "")
+			// remove leading and trailing spaces from value before Trim (needed to support multiline overrides e.g ", ")
+			v = strings.TrimSpace(v)
 			if len(v) > 0 && v != "" {
 				util.LogDebug.Printf("processing iter :%v value :%v", k, v)
 				overrides = append(overrides, v)

--- a/common/k8s/provisioner/provisioner.go
+++ b/common/k8s/provisioner/provisioner.go
@@ -51,7 +51,7 @@ const (
 	//TODO allow this to be set per docker volume driver
 	maxCreates = 4
 	//TODO allow this to be set per docker volume driver
-	maxDeletes                 = 4
+	maxDeletes                 = 10
 	defaultSocketFile          = "/run/docker/plugins/nimble.sock"
 	defaultfactorForConversion = 1073741824
 	defaultStripValue          = true
@@ -61,6 +61,8 @@ const (
 	cloneOfPVC                 = "cloneOfPVC"
 	manager                    = "manager"
 	managerName                = "k8s"
+	id2chanMapSize             = 1024
+	deleteRetrySleep           = 5 * time.Second
 )
 
 var (
@@ -160,6 +162,7 @@ func (p *Provisioner) sendUpdate(t interface{}) {
 
 // removeMessageChan closes (if open) chan and removes it from the map
 func (p *Provisioner) removeMessageChan(claimID string, volID string) {
+	util.LogDebug.Printf("removeMessageChan called with claimID %s volID %s", claimID, volID)
 	p.id2chanLock.Lock()
 	defer p.id2chanLock.Unlock()
 
@@ -189,10 +192,10 @@ func NewProvisioner(clientSet *kubernetes.Clientset, provisionerName string, aff
 	id := uuid.NewV4()
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(&core_v1.EventSinkImpl{Interface: clientSet.Core().Events(v1.NamespaceAll)})
-	util.LogDebug.Printf("provisioner (prefix=%s) is being created with instance id %s.", provisionerName, id.String())
+	util.LogDebug.Printf("provisioner (prefix=%s) is being created with instance id %s and id2chan capacity %d.", provisionerName, id.String(), id2chanMapSize)
 	return &Provisioner{
 		kubeClient:              clientSet,
-		id2chan:                 make(map[string]chan *updateMessage, 100),
+		id2chan:                 make(map[string]chan *updateMessage, id2chanMapSize), //make a id to chan (updatemessage) map with a capacity of id2chanMapSize
 		id2chanLock:             &sync.Mutex{},
 		affectDockerVols:        affectDockerVols,
 		namePrefix:              provisionerName + "/",
@@ -303,13 +306,13 @@ func (p *Provisioner) statusLogger() {
 
 func (p *Provisioner) deleteVolume(pv *api_v1.PersistentVolume, rmPV bool) {
 	provisioner := pv.Annotations[k8sProvisionedBy]
-
+	util.LogDebug.Printf("in deleteVolume: cleaning up pv:%s Status:%v with deleteChain %d parkedCommands %d with affectDockerVols %v", pv.Name, pv.Status, atomic.LoadUint32(&p.deleteCommandChains), atomic.LoadUint32(&p.parkedCommands), p.affectDockerVols)
 	// slow down a delete storm
 	limit(&p.deleteCommandChains, &p.parkedCommands, maxDeletes)
 
 	atomic.AddUint32(&p.deleteCommandChains, 1)
 	defer atomic.AddUint32(&p.deleteCommandChains, ^uint32(0))
-	deleteChain := chain.NewChain(chainRetries, chainTimeout)
+	deleteChain := chain.NewChain(chainRetries, deleteRetrySleep)
 
 	// if the pv was just deleted, make sure we clean up the docker volume
 	if p.affectDockerVols {


### PR DESCRIPTION
* Problem:
- dockerVol used to timeout for large number of mount requests
- doryd queues used to block the delete queue with a timeer of 2 minutes for 3 tries (6 minutes)
- some of the conditions for unmount differred for failover scenarios
* Implementation:
- increase dockerVol Client timeout
- decrease doryd deleteChain timeout to 5 secons so that a PV delete blocks the delete queue
for a max of 5*3 = 15 seconds
- handle some of the error conditions for unmount